### PR TITLE
Fix command-finding code, and error out if we can't find commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ Usage
 A simple test without installing:
 
 ~~~~ bash
-wget -qO - https://raw.githubusercontent.com/websafe/ffbx/master/ffbx.sh | bash
+wget -qO - https://raw.githubusercontent.com/chbarts/ffbx/master/ffbx.sh | bash
 ~~~~
 
 or:
 
 ~~~~ bash
-lynx -dump https://raw.githubusercontent.com/websafe/ffbx/master/ffbx.sh | bash
+lynx -dump https://raw.githubusercontent.com/chbarts/ffbx/master/ffbx.sh | bash
 ~~~~
 
 or:
 
 ~~~~ bash
-curl -sS https://raw.githubusercontent.com/websafe/ffbx/master/ffbx.sh | bash
+curl -sS https://raw.githubusercontent.com/chbarts/ffbx/master/ffbx.sh | bash
 ~~~~
 
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Simple Bash script using sqlite3 for extracting bookmarks from
 Bookmarks are extracted with:
 
  + timestamp of last modification,
+ + date added,
  + profile name,
  + folder,
  + url,

--- a/README.md
+++ b/README.md
@@ -69,15 +69,13 @@ ffbx.sh ~/.mozilla/firefox/ffbx-example/places.sqlite
 the result:
 
 ~~~~
-1391725993809844        Bookmarks Toolbar       https://www.mozilla.org/en-US/firefox/central/  Getting Started
-1391725993811277        Mozilla Firefox https://www.mozilla.org/en-US/firefox/help/     Help and Tutorials
-1391725993812029        Mozilla Firefox https://www.mozilla.org/en-US/firefox/customize/        Customize Firefox
-1391725993812829        Mozilla Firefox https://www.mozilla.org/en-US/contribute/       Get Involved
-1391725993813492        Mozilla Firefox https://www.mozilla.org/en-US/about/    About Us
-1391725993870487        Bookmarks Toolbar       place:sort=8&maxResults=10      Most Visited
-1391725993870988        Bookmarks Menu  place:folder=BOOKMARKS_MENU&folder=UNFILED_BOOKMARKS&folder=TOOLBAR&queryType=1&sort=12&maxResults=10&excludeQueries=1  Recently Bookmarked
-1391725993871436        Bookmarks Menu  place:type=6&sort=14&maxResults=10      Recent Tags
-1391726063106065        Unsorted Bookmarks      https://github.com/websafe/ffbx websafe/ffbx · GitHub   Firefox,bookmarks,extract,Bash,script,SQLite
+1475596075859000	1475596075857000	Bookmarks Toolbar	https://www.mozilla.org/en-US/firefox/central/	Getting Started	
+1475596075862000	1475596075861000	Mozilla Firefox	https://www.mozilla.org/en-US/firefox/help/	Help and Tutorials	
+1475596075863000	1475596075863000	Mozilla Firefox	https://www.mozilla.org/en-US/firefox/customize/	Customize Firefox	
+1475596075865000	1475596075864000	Mozilla Firefox	https://www.mozilla.org/en-US/contribute/	Get Involved	
+1475596075866000	1475596075866000	Mozilla Firefox	https://www.mozilla.org/en-US/about/	About Us	
+1475596075945000	1475596075889000	Bookmarks Toolbar	place:sort=8&maxResults=10	Most Visited	
+1475596075985000	1475596075949000	Bookmarks Menu	place:type=6&sort=14&maxResults=10	Recent Tags	
 ~~~~
 
 
@@ -99,75 +97,66 @@ the result:
 ~~~~
 Array
 (
-    [0] => 1391725993809844
-    [1] => Bookmarks Toolbar
-    [2] => https://www.mozilla.org/en-US/firefox/central/
-    [3] => Getting Started
-    [4] => 
+    [0] => 1475596075859000
+    [1] => 1475596075857000
+    [2] => Bookmarks Toolbar
+    [3] => https://www.mozilla.org/en-US/firefox/central/
+    [4] => Getting Started
+    [5] => 
 )
 Array
 (
-    [0] => 1391725993811277
-    [1] => Mozilla Firefox
-    [2] => https://www.mozilla.org/en-US/firefox/help/
-    [3] => Help and Tutorials
-    [4] => 
+    [0] => 1475596075862000
+    [1] => 1475596075861000
+    [2] => Mozilla Firefox
+    [3] => https://www.mozilla.org/en-US/firefox/help/
+    [4] => Help and Tutorials
+    [5] => 
 )
 Array
 (
-    [0] => 1391725993812029
-    [1] => Mozilla Firefox
-    [2] => https://www.mozilla.org/en-US/firefox/customize/
-    [3] => Customize Firefox
-    [4] => 
+    [0] => 1475596075863000
+    [1] => 1475596075863000
+    [2] => Mozilla Firefox
+    [3] => https://www.mozilla.org/en-US/firefox/customize/
+    [4] => Customize Firefox
+    [5] => 
 )
 Array
 (
-    [0] => 1391725993812829
-    [1] => Mozilla Firefox
-    [2] => https://www.mozilla.org/en-US/contribute/
-    [3] => Get Involved
-    [4] => 
+    [0] => 1475596075865000
+    [1] => 1475596075864000
+    [2] => Mozilla Firefox
+    [3] => https://www.mozilla.org/en-US/contribute/
+    [4] => Get Involved
+    [5] => 
 )
 Array
 (
-    [0] => 1391725993813492
-    [1] => Mozilla Firefox
-    [2] => https://www.mozilla.org/en-US/about/
-    [3] => About Us
-    [4] => 
+    [0] => 1475596075866000
+    [1] => 1475596075866000
+    [2] => Mozilla Firefox
+    [3] => https://www.mozilla.org/en-US/about/
+    [4] => About Us
+    [5] => 
 )
 Array
 (
-    [0] => 1391725993870487
-    [1] => Bookmarks Toolbar
-    [2] => place:sort=8&maxResults=10
-    [3] => Most Visited
-    [4] => 
+    [0] => 1475596075945000
+    [1] => 1475596075889000
+    [2] => Bookmarks Toolbar
+    [3] => place:sort=8&maxResults=10
+    [4] => Most Visited
+    [5] => 
 )
 Array
 (
-    [0] => 1391725993870988
-    [1] => Bookmarks Menu
-    [2] => place:folder=BOOKMARKS_MENU&folder=UNFILED_BOOKMARKS&folder=TOOLBAR&queryType=1&sort=12&maxResults=10&excludeQueries=1
-    [3] => Recently Bookmarked
-    [4] => 
-)
-Array
-(
-    [0] => 1391725993871436
-    [1] => Bookmarks Menu
-    [2] => place:type=6&sort=14&maxResults=10
-    [3] => Recent Tags
-    [4] => 
-)
-Array
-(
-    [0] => 1391726063106065
-    [1] => Unsorted Bookmarks
-    [2] => https://github.com/websafe/ffbx
-    [3] => websafe/ffbx · GitHub
-    [4] => Firefox,bookmarks,extract,Bash,script,SQLite,
+    [0] => 1475596075985000
+    [1] => 1475596075949000
+    [2] => Bookmarks Menu
+    [3] => place:type=6&sort=14&maxResults=10
+    [4] => Recent Tags
+    [5] => 
 )
 ~~~~
 
@@ -186,14 +175,12 @@ ffbx.sh \
 the result:
 
 ~~~~
-["1391725993809844","Bookmarks Toolbar","https:\/\/www.mozilla.org\/en-US\/firefox\/central\/","Getting Started",""]
-["1391725993811277","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/firefox\/help\/","Help and Tutorials",""]
-["1391725993812029","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/firefox\/customize\/","Customize Firefox",""]
-["1391725993812829","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/contribute\/","Get Involved",""]
-["1391725993813492","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/about\/","About Us",""]
-["1391725993870487","Bookmarks Toolbar","place:sort=8&maxResults=10","Most Visited",""]
-["1391725993870988","Bookmarks Menu","place:folder=BOOKMARKS_MENU&folder=UNFILED_BOOKMARKS&folder=TOOLBAR&queryType=1&sort=12&maxResults=10&excludeQueries=1","Recently Bookmarked",""]
-["1391725993871436","Bookmarks Menu","place:type=6&sort=14&maxResults=10","Recent Tags",""]
-["1391726063106065","Unsorted Bookmarks","https:\/\/github.com\/websafe\/ffbx","websafe\/ffbx \u00b7 GitHub","Firefox,bookmarks,extract,Bash,script,SQLite,"]
+["1475596075859000","1475596075857000","Bookmarks Toolbar","https:\/\/www.mozilla.org\/en-US\/firefox\/central\/","Getting Started",""]
+["1475596075862000","1475596075861000","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/firefox\/help\/","Help and Tutorials",""]
+["1475596075863000","1475596075863000","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/firefox\/customize\/","Customize Firefox",""]
+["1475596075865000","1475596075864000","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/contribute\/","Get Involved",""]
+["1475596075866000","1475596075866000","Mozilla Firefox","https:\/\/www.mozilla.org\/en-US\/about\/","About Us",""]
+["1475596075945000","1475596075889000","Bookmarks Toolbar","place:sort=8&maxResults=10","Most Visited",""]
+["1475596075985000","1475596075949000","Bookmarks Menu","place:type=6&sort=14&maxResults=10","Recent Tags",""]
 false
 ~~~~

--- a/ffbx.sh
+++ b/ffbx.sh
@@ -194,6 +194,16 @@ do
 
         debug "bookmark_last_modification ${bookmark_last_modification}"
 
+        # Retrieve added timestamp for the current bookmark:
+        bookmark_date_added=$(
+            ${CMD_SQLITE3} "${db_places_path}" \
+                "SELECT dateAdded FROM moz_bookmarks
+                    WHERE fk=${bookmark_places_id} 
+                    ORDER BY dateAdded DESC LIMIT 1"
+        )
+
+        debug "bookmark_date_added ${bookmark_date_added}"
+
         # Retrieve id of current bookmarks parent folder:
         bookmark_folder_id=$(
             ${CMD_SQLITE3} "${db_places_path}" \
@@ -215,6 +225,7 @@ do
 
         # Output CSV data:
         echo -ne "${bookmark_last_modification}"
+        echo -ne "${bookmark_date_added}"
         if [ "${db_places_paths_were_autodiscovered}" = "yes" ];
         then
             echo -ne "${FFBX_FIELD_SEPARATOR}"

--- a/ffbx.sh
+++ b/ffbx.sh
@@ -27,6 +27,31 @@ CMD_SQLITE3=${CMD_SQLITE3:-$(which sqlite3)}
 CMD_TR=${CMD_TR:-$(which tr)}
 CMD_UNIQ=${CMD_UNIQ:-$(which uniq)}
 
+if [ ! -f "${CMD_CUT}" ]; then
+    echo "cut not found" >/dev/stderr
+    exit 1
+fi
+
+if [ ! -f "${CMD_FIND}" ]; then
+    echo "find not found" >/dev/stderr
+    exit 1
+fi
+
+if [ ! -f "${CMD_SQLITE3}" ]; then
+    echo "sqlite3 not found" >/dev/stderr
+    exit 1
+fi
+
+if [ ! -f "${CMD_TR}" ]; then
+    echo "tr not found" >/dev/stderr
+    exit 1
+fi
+
+if [ ! -f "${CMD_UNIQ}" ]; then
+    echo "uniq not found" >/dev/stderr
+    exit 1
+fi
+
 # 
 FFBX_FIELD_SEPARATOR=${FFBX_FIELD_SEPARATOR:-"\t"}
 FFBX_ROW_SEPARATOR=${FFBX_ROW_SEPARATOR:-"\n"}

--- a/ffbx.sh
+++ b/ffbx.sh
@@ -225,6 +225,7 @@ do
 
         # Output CSV data:
         echo -ne "${bookmark_last_modification}"
+        echo -ne "${FFBX_FIELD_SEPARATOR}"
         echo -ne "${bookmark_date_added}"
         if [ "${db_places_paths_were_autodiscovered}" = "yes" ];
         then

--- a/ffbx.sh
+++ b/ffbx.sh
@@ -21,11 +21,11 @@ IFS="
 "
 
 #
-CMD_CUT=${CMD_CUT:-/bin/cut}
-CMD_FIND=${CMD_FIND:-/usr/bin/find}
-CMD_SQLITE3=${CMD_SQLITE3:-/usr/bin/sqlite3}
-CMD_TR=${CMD_TR:-/bin/tr}
-CMD_UNIQ=${CMD_UNIQ:-/bin/uniq}
+CMD_CUT=${CMD_CUT:-$(which cut)}
+CMD_FIND=${CMD_FIND:-$(which find)}
+CMD_SQLITE3=${CMD_SQLITE3:-$(which sqlite3)}
+CMD_TR=${CMD_TR:-$(which tr)}
+CMD_UNIQ=${CMD_UNIQ:-$(which uniq)}
 
 # 
 FFBX_FIELD_SEPARATOR=${FFBX_FIELD_SEPARATOR:-"\t"}

--- a/humanize-datestamps
+++ b/humanize-datestamps
@@ -1,0 +1,20 @@
+#!/usr/bin/awk -f
+# Convert datestamps to a human-readable form
+
+function ctime(ts)
+{
+    return strftime("%a %b %e %H:%M:%S %Z %Y", ts);
+}
+
+BEGIN {
+    FS="\t"
+    OFS="\t"
+}
+
+{
+    $1 = ctime(sprintf("%d", $1/1000000))
+    $2 = ctime(sprintf("%d", $2/1000000))
+    $1 = $1 # Rebuild the records...
+    $2 = $2
+    print $0
+}


### PR DESCRIPTION
Update the command-finding code to use which to reliably find the commands we need, and error out gracefully if we cannot find those commands.
